### PR TITLE
feat: Adding sorting feature to launches page and store refactor

### DIFF
--- a/src/constants/uiConstants.js
+++ b/src/constants/uiConstants.js
@@ -7,3 +7,18 @@ export const CATEGORY_MAP = {
   launches: "Launches",
   launchPads: "Launch Pads",
 };
+
+export const LAUNCH_SORT_KEYS = {
+  recent_launch: {
+    sort: "launch_date_utc",
+    order: "desc",
+  },
+  oldest_launch: {
+    sort: "launch_date_utc",
+    order: "asc",
+  },
+  name: {
+    sort: "mission_name",
+    order: "asc",
+  },
+};

--- a/src/containers/Launches/Details/index.js
+++ b/src/containers/Launches/Details/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useParams, Link as RouterLink } from "react-router-dom";
 import { format as timeAgo } from "timeago.js";
 import { Watch, MapPin, Navigation, Layers } from "react-feather";
@@ -28,9 +28,12 @@ import Error from "components/error";
 import Breadcrumbs from "components/breadcrumbs";
 import Timezones from "constants/timezones";
 import AddToFavourites from "components/AddToFavourites";
+import { AppStateContext } from "store";
 
 export default function Launch() {
   let { launchId } = useParams();
+  const AppState = useContext(AppStateContext);
+
   const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
 
   if (error) return <Error />;
@@ -42,12 +45,18 @@ export default function Launch() {
     );
   }
 
+  let sortKey = "";
+
+  if (AppState?.sort?.launches !== undefined) {
+    sortKey = `sort=${AppState?.sort?.launches}`;
+  }
+
   return (
     <div>
       <Breadcrumbs
         items={[
           { label: "Home", to: "/" },
-          { label: "Launches", to: "/launches" },
+          { label: "Launches", to: `/launches?${sortKey}` },
           { label: `#${launch.flight_number}` },
         ]}
       />

--- a/src/containers/Launches/index.js
+++ b/src/containers/Launches/index.js
@@ -1,34 +1,82 @@
-import React from "react";
+import React, { useState, useContext } from "react";
+import { Select, Flex } from "@chakra-ui/react";
+
 import { useSpaceXPaginated } from "utils/use-space-x";
 import Error from "components/error";
 import Breadcrumbs from "components/breadcrumbs";
 import LaunchItem from "./LaunchItem";
 import VirtualizedGrid from "components/VirtualizedGrid";
+import { LAUNCH_SORT_KEYS } from "constants/uiConstants";
+import { DispatchContext } from "store";
+
+import { useSearchParams } from "react-router-dom";
 
 const PAGE_SIZE = 12;
 
 export default function Launches() {
+  const AppDispatch = useContext(DispatchContext);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  let intialSortVal = "recent_launch";
+
+  if (!searchParams.get("sort")) {
+    setSearchParams({ sort: "recent_launch" });
+  } else {
+    intialSortVal = searchParams.get("sort");
+  }
+
+  const [sortValue, setSort] = useState(LAUNCH_SORT_KEYS[intialSortVal]);
+
   const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
     "/launches/past",
     {
       limit: PAGE_SIZE,
-      order: "desc",
-      sort: "launch_date_utc",
+      ...sortValue,
     }
   );
 
   const flattenData = data?.flat();
+
+  function handleChange(event) {
+    let { target } = event;
+
+    setSort(LAUNCH_SORT_KEYS[target.value]);
+    setSearchParams({ sort: target.value });
+
+    return AppDispatch({
+      type: "setSort",
+      payload: {
+        type: "launches",
+        data: target.value,
+      },
+    });
+  }
 
   const Item = (index) => {
     let content = flattenData[index];
     return <LaunchItem key={content.flight_number} launch={content} />;
   };
 
+  const currSortKey = searchParams.get("sort");
+
   return (
     <>
-      <Breadcrumbs
-        items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
-      />
+      <Flex justifyContent="space-between" alignItems="center">
+        <Breadcrumbs
+          items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
+        />
+        <Select
+          value={currSortKey}
+          width="15%"
+          size="sm"
+          onChange={handleChange}
+          mr="6"
+        >
+          <option value="recent_launch">Recent launch</option>
+          <option value="oldest_launch">Oldest launch</option>
+          <option value="name">Name</option>
+        </Select>
+      </Flex>
 
       {error && <Error />}
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,19 +1,20 @@
 import React, { useReducer } from "react";
 
 import FavouritesReducer from "./reducers/favourites";
+import SortReducer from "./reducers/sort";
 import { fetchFromLocal } from "utils/sync-localstorage";
+import combinedReducers from "utils/combinedReducers";
 
-const INITAL_STATE = {
-  favourites: {},
-};
-
-const AppState = fetchFromLocal("appState", INITAL_STATE);
+const FavouritesState = fetchFromLocal("appState", {});
 
 export const AppStateContext = React.createContext();
 export const DispatchContext = React.createContext();
 
 export default function Store({ children }) {
-  const [state, dispatch] = useReducer(FavouritesReducer, AppState);
+  const [state, dispatch] = combinedReducers({
+    favourites: useReducer(FavouritesReducer, FavouritesState),
+    sort: useReducer(SortReducer, {}),
+  });
 
   return (
     <AppStateContext.Provider value={state}>

--- a/src/store/reducers/favourites.js
+++ b/src/store/reducers/favourites.js
@@ -2,17 +2,16 @@ import { syncToLocal } from "utils/sync-localstorage";
 import { STORE_KEYS } from "constants/uiConstants";
 
 const favouriteReducer = (state, action) => {
-  let { favourites } = state;
   let { payload } = action;
   let categoryKey = payload.type;
 
   switch (action.type) {
     case "addFavourite": {
-      if (!(categoryKey in favourites)) {
-        favourites[categoryKey] = {};
+      if (!(categoryKey in state)) {
+        state[categoryKey] = {};
       }
 
-      let favouritesCategory = favourites[categoryKey];
+      let favouritesCategory = state[categoryKey];
       let payloadKey = STORE_KEYS[categoryKey];
 
       let payloadId = payload.data[payloadKey];
@@ -20,11 +19,11 @@ const favouriteReducer = (state, action) => {
       favouritesCategory[payloadId] = payload.data;
       syncToLocal("appState", state);
 
-      return Object.assign({}, state, { favourites });
+      return Object.assign({}, state);
     }
 
     case "removeFavourite": {
-      let favouritesCategory = favourites[categoryKey];
+      let favouritesCategory = state[categoryKey];
 
       if (favouritesCategory === undefined) {
         return Object.assign({}, state);
@@ -36,15 +35,15 @@ const favouriteReducer = (state, action) => {
       delete favouritesCategory[payloadId];
 
       if (Object.keys(favouritesCategory).length === 0) {
-        delete favourites[categoryKey];
+        delete state[categoryKey];
       }
 
       syncToLocal("appState", state);
-      return Object.assign({}, state, { favourites });
+      return Object.assign({}, state);
     }
 
     default:
-      break;
+      return state;
   }
 };
 

--- a/src/store/reducers/sort.js
+++ b/src/store/reducers/sort.js
@@ -1,0 +1,17 @@
+const sortReducer = (state, action) => {
+  switch (action.type) {
+    case "setSort": {
+      let { payload } = action;
+      let categoryKey = payload.type;
+
+      state[categoryKey] = payload.data ?? "";
+
+      return Object.assign({}, state);
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default sortReducer;

--- a/src/utils/combinedReducers.js
+++ b/src/utils/combinedReducers.js
@@ -1,0 +1,19 @@
+export default function combinedReducer(combinedReducers) {
+  const appKeys = Object.keys(combinedReducers);
+
+  const state = appKeys.reduce((acc, key) => {
+    return {
+      ...acc,
+      [key]: combinedReducers[key][0],
+    };
+  }, {});
+
+  const dispatch = (action) => {
+    appKeys.forEach((key) => {
+      let [, /*state*/ dispatchAction] = combinedReducers[key];
+      dispatchAction(action);
+    });
+  };
+
+  return [state, dispatch];
+}


### PR DESCRIPTION
**Description**

Users would be able to sort through list of launches by clicking on the dropdown in the header. They can sort based on
- Name
- Oldest launch
- Recent launch.

Users can also sortby changing in the URL of the webpage. The sort option will persist between page transition as it been stored in the context.

This PR also consists of a refactor of the store implementation, it now supports multiple reducers, hence multiple types of state can be used.

**Thought process**

Have only implemented for the launches page since the API support is available and for the launch pads there is no API support and amount of data is very limited to get meaningful insights via sorting. 

**Steps to test**

- Visit home page and click on "Browse SpaceX Launches"
- Click on the dropdown and choose an option ex- Recent launch
- The page will be refreshed with the new set of data - The url will also reflect the change
- Click on any item from the list.
- Go back to the previous page via breadcrumb or browser back. The sort order option will be persisted.

**After**

<img width="1440" alt="Screenshot 2021-11-23 at 6 58 03 AM" src="https://user-images.githubusercontent.com/23741529/142958970-c4d9844c-777c-4cb5-be22-57f07c9196bf.png">


